### PR TITLE
Fix JSON output for created / deleted empty files

### DIFF
--- a/src/display/json.rs
+++ b/src/display/json.rs
@@ -3,6 +3,8 @@ use line_numbers::LineNumber;
 use regex::Regex;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
+use crate::display::side_by_side::lines_with_novel;
+use crate::parse::syntax::NON_EXISTENT_PERMISSIONS;
 use crate::{
     display::{
         context::{all_matched_lines_filled, opposite_positions},
@@ -12,8 +14,6 @@ use crate::{
     parse::syntax::{self, MatchedPos, StringKind},
     summary::{DiffResult, FileContent, FileFormat},
 };
-use crate::display::side_by_side::lines_with_novel;
-use crate::parse::syntax::NON_EXISTENT_PERMISSIONS;
 
 lazy_static! {
     static ref FILE_PERMS_RE: Regex =

--- a/src/display/json.rs
+++ b/src/display/json.rs
@@ -129,7 +129,13 @@ impl<'f> From<&'f DiffResult> for File<'f> {
                         match (from.as_str(), to.as_str()) {
                             (NON_EXISTENT_PERMISSIONS, _) => Status::Created,
                             (_, NON_EXISTENT_PERMISSIONS) => Status::Deleted,
-                            _ => Status::Changed,
+                            _ => {
+                                if from == to {
+                                    Status::Unchanged
+                                } else {
+                                    Status::Changed
+                                }
+                            }
                         }
                     } else {
                         Status::Unchanged

--- a/src/display/json.rs
+++ b/src/display/json.rs
@@ -3,8 +3,6 @@ use line_numbers::LineNumber;
 use regex::Regex;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
-use crate::display::side_by_side::lines_with_novel;
-use crate::parse::syntax::NON_EXISTENT_PERMISSIONS;
 use crate::{
     display::{
         context::{all_matched_lines_filled, opposite_positions},
@@ -14,6 +12,8 @@ use crate::{
     parse::syntax::{self, MatchedPos, StringKind},
     summary::{DiffResult, FileContent, FileFormat},
 };
+use crate::display::side_by_side::lines_with_novel;
+use crate::parse::syntax::NON_EXISTENT_PERMISSIONS;
 
 lazy_static! {
     static ref FILE_PERMS_RE: Regex =
@@ -125,7 +125,6 @@ impl<'f> From<&'f DiffResult> for File<'f> {
                     let status = if File::extract_old_path(&summary.extra_info).is_some() {
                         Status::Renamed
                     } else if let Some((from, to)) = File::extract_status(&summary.extra_info) {
-                        println!("{from} -> {to}");
                         match (from.as_str(), to.as_str()) {
                             (NON_EXISTENT_PERMISSIONS, _) => Status::Created,
                             (_, NON_EXISTENT_PERMISSIONS) => Status::Deleted,

--- a/src/options.rs
+++ b/src/options.rs
@@ -12,6 +12,7 @@ use const_format::formatcp;
 use crossterm::tty::IsTty;
 use itertools::Itertools;
 
+use crate::parse::syntax::NON_EXISTENT_PERMISSIONS;
 use crate::{
     display::style::BackgroundColor,
     exit_codes::EXIT_BAD_ARGUMENTS,
@@ -357,14 +358,12 @@ impl Display for FilePermissions {
     }
 }
 
-impl TryFrom<&OsStr> for FilePermissions {
-    type Error = ();
-
-    fn try_from(s: &OsStr) -> Result<Self, Self::Error> {
+impl From<&OsStr> for FilePermissions {
+    fn from(s: &OsStr) -> Self {
         if s == "." {
-            Err(())
+            Self(NON_EXISTENT_PERMISSIONS.to_owned())
         } else {
-            Ok(Self(s.to_string_lossy().into_owned()))
+            Self(s.to_string_lossy().into_owned())
         }
     }
 }

--- a/src/parse/syntax.rs
+++ b/src/parse/syntax.rs
@@ -19,6 +19,8 @@ use crate::{
     lines::is_all_whitespace,
 };
 
+pub const NON_EXISTENT_PERMISSIONS: &'static str = "0000000";
+
 /// A Debug implementation that does not recurse into the
 /// corresponding node mentioned for Unchanged. Otherwise we will
 /// infinitely loop on unchanged nodes, which both point to the other.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -212,7 +212,7 @@ fn git_style_arguments_new_file() {
         .arg("sample_files/simple_1.txt")
         .arg("abcdef1234")
         .arg("100644");
-    let predicate_fn = predicate::str::contains("File permissions changed").not();
+    let predicate_fn = predicate::str::contains("File permissions changed");
     cmd.assert().stdout(predicate_fn);
 }
 


### PR DESCRIPTION
<!-- user_description heading -->
# User description
<!-- user_description start -->
Until https://github.com/Wilfred/difftastic/issues/259 is addressed, this is a workaround specifically for the JSON output. Instead of crashing when calculating the permissions, returning the code that git returns and acting accordingly (marking the file as created / deleted). Example outputs:

```sh
$ GIT_EXTERNAL_DIFF=../difft DFT_UNSTABLE=yes DFT_DISPLAY=json git diff main...999c619
{"language":"Python","path":"python/__init__.py","status":"created"}
```

```sh
GIT_EXTERNAL_DIFF=../difft DFT_UNSTABLE=yes DFT_DISPLAY=json git diff 999c619...HEAD
{"language":"Python","path":"python/__init__.py","status":"deleted"}
```
<!-- user_description end -->

---

<!-- generated_description heading -->
# Generated description
<!-- generated_description start -->
A pull request with no changes.

## Topics


<!-- generated_description end -->